### PR TITLE
add dependency on amp-log-agent when used with containerPilot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN chmod +x /*.sh
 #ENV CONSUL=consul:8500
 ENV CP_LOG_LEVEL=ERROR
 ENV CONTAINERPILOT=file:///etc/containerpilot.json
-ENV DEPENDENCIES=influxdb
+ENV DEPENDENCIES="influxdb amp-log-agent"
 
 CMD ["/start.sh"]
 


### PR DESCRIPTION
to have the log in kibana
