### PR TITLE
Default retention policy for InfluxDB 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Most basic form:
 
     docker run -t -v /var/run/docker.sock:/var/run/docker.sock:ro appcelerator/telegraf
 
-Custom InfluxDB location and additional tags:
+Custom InfluxDB location, additional tags, and retention policy for InfluxDB 1.0.0 :
 
-    docker run -t -v /var/run/docker.sock:/var/run/docker.sock:ro -v /var/run/utmp:/var/run/utmp:ro -e INFLUXDB_URL=http://influxdb:8086 -e TAG_datacenter=eu-central-1 -e TAG_type=core appcelerator/telegraf
+    docker run -t -v /var/run/docker.sock:/var/run/docker.sock:ro -v /var/run/utmp:/var/run/utmp:ro -e INFLUXDB_URL=http://influxdb:8086 -e TAG_datacenter=eu-central-1 -e TAG_type=core -e INFLUXDB_RETENTION_POLICY= appcelerator/telegraf
 
 # Configuration (ENV, -e)
 
@@ -44,7 +44,7 @@ INPUT_NET_ENABLED | enable net metrics | true |
 INPUT_LISTENER_ENABLED | enable generic TCP listener | false |
 INPUT_DOCKER_ENABLED | enable Docker metrics | true |
 INFLUXDB_URL | Where is your InfluxDB running? | http://localhost:8086 | http://influxdb:8086
-INFLUXDB_RETENTION_POLICY | Set the name of the policy | default | ""
+INFLUXDB_RETENTION_POLICY | Set the name of the policy | default | 
 INFLUXDB_USER | InfluxDB username | |
 INFLUXDB_PASS | InfluxDB password | metrics |
 INFLUXDB_TIMEOUT | InfluxDB timetout (in seconds) | 5 |

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ INPUT_NET_ENABLED | enable net metrics | true |
 INPUT_LISTENER_ENABLED | enable generic TCP listener | false |
 INPUT_DOCKER_ENABLED | enable Docker metrics | true |
 INFLUXDB_URL | Where is your InfluxDB running? | http://localhost:8086 | http://influxdb:8086
+INFLUXDB_RETENTION_POLICY | Set the name of the policy | default | ""
 INFLUXDB_USER | InfluxDB username | |
 INFLUXDB_PASS | InfluxDB password | metrics |
 INFLUXDB_TIMEOUT | InfluxDB timetout (in seconds) | 5 |

--- a/telegraf.conf.tpl
+++ b/telegraf.conf.tpl
@@ -77,7 +77,7 @@
   ## The target database for metrics (telegraf will create it if not exists).
   database = "telegraf" # required
   ## Retention policy to write to.
-  retention_policy = "default"
+  retention_policy = "{{ INFLUXDB_RETENTION_POLICY | default("default") }}"
   ## Precision of writes, valid values are "ns", "us", "ms", "s", "m", "h".
   ## note: using "s" precision greatly improves InfluxDB compression.
   precision = "s"


### PR DESCRIPTION
Hi, I found an issue and came up with a way to fix it.
The issue: InfluxDB changed the name of the default retention policy in 1.0.0 from "default" to "autogen". The telegraf.conf.tpl file needs to be updated.
Proposed fix: To make this work and be backwards compatible I created an env variable for the policy name. I have it defaulting to "default". It could default to "", which is what the telegraf 1.0.0 telegraf.conf file has.
To make it clear how to use it I added it to the custom example at the top of the readme.
